### PR TITLE
package: use the devDependencies for the node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "next-update": "0.9.2"
   },
   "scripts": {
-    "lint": "eslint ./",
-    "test": "npm run lint && istanbul cover _mocha -- ./test",
+    "lint": "node_modules/.bin/eslint ./",
+    "test": "npm run lint && node_modules/.bin/istanbul cover _mocha -- ./test",
     "update": "next-update -k",
-    "log": "changelog42 --no-author --commit-url=https://github.com/skenqbx/module-template/commit",
+    "log": "node_modules/.bin/changelog42 --no-author --commit-url=https://github.com/skenqbx/module-template/commit",
     "clean": "rm -rf node_modules/ && rm -rf coverage/ && rm -f npm-debug.log",
     "postinstall": "if test -d .git/hooks; then echo '#!/bin/sh\\nnpm test' > .git/hooks/pre-commit && chmod u+x .git/hooks/pre-commit; fi"
   },


### PR DESCRIPTION
If you use the node scripts as defined the global installation of the node modules are used. I changed the invocations so the scripts use the defined dependencies.
