### PR TITLE
updates mocha to 5.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "devDependencies": {
     "eslint": "4.6.1",
     "nyc": "11.2.1",
-    "mocha": "3.5.3"
+    "mocha": "5.2.0"
   },
   "scripts": {
     "lint": "eslint ./",


### PR DESCRIPTION
mocha 3.5.3 uses growl 1.9.x, which has a known security issue: https://nodesecurity.io/advisories/146
Updating to 5.2.0 which only 

- drops support for [unsupported nodejs version](https://github.com/mochajs/mocha/releases/tag/v4.0.0) (0.10, 0.11, ...) and
- drops [support for IE9, IE10](https://github.com/mochajs/mocha/releases/tag/v5.0.0) 

should do great.
